### PR TITLE
feat: 홈페이지 삭제

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_sns_app/firebase_options.dart';
 import 'package:flutter_sns_app/presentation/pages/comment_page.dart';
@@ -9,7 +8,6 @@ import 'package:firebase_core/firebase_core.dart';
 import 'presentation/pages/splash_page.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
-
 void main() async {
   SentryWidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(
@@ -18,19 +16,14 @@ void main() async {
   await SentryFlutter.init(
     (options) {
       options.dsn = 'https://2c3efcc8e9684c23523a2a209f6dbcf6@o4509353960538112.ingest.us.sentry.io/4509353979936768';
-      // Adds request headers and IP for users, for more info visit:
-      // https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/
       options.sendDefaultPii = true;
-      // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
-      // We recommend adjusting this value in production.
       options.tracesSampleRate = 1.0;
-      // The sampling rate for profiling is relative to tracesSampleRate
-      // Setting to 1.0 will profile 100% of sampled transactions:
       options.profilesSampleRate = 1.0;
     },
     appRunner: () => runApp(SentryWidget(child: const ProviderScope(child: MyApp()))),
   );
-  // TODO: Remove this line after sending the first sample event to sentry.
+
+  // 테스트용 에러 전송 (완료되면 제거 가능)
   await Sentry.captureException(StateError('This is a sample exception.'));
 }
 
@@ -45,69 +38,12 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      initialRoute: '/',
+      home: const SplashPage(), // 앱 시작 시 SplashPage로 진입
       routes: {
-        '/': (context) => const HomePage(),
         '/post_create': (context) => const PostCreatePage(),
-        '/comment': (context) {
-          // postId 제거, comments만 빈 리스트로 넘김
-          return const CommentPage(postId: '75e46e13-0986-425c-96a1-e9132eb74ded'); //test용 postId
-        },
+        '/comment': (context) => const CommentPage(postId: '75e46e13-0986-425c-96a1-e9132eb74ded'), // test용
         '/post_list': (context) => const PostListPage(),
-        '/splash': (context) => const SplashPage(),
       },
-    );
-  }
-}
-
-class HomePage extends StatelessWidget {
-  const HomePage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Flutter SNS App'),
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Text('Welcome to Flutter SNS App'),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    // postId 제거
-                    builder: (context) => const CommentPage(postId: '75e46e13-0986-425c-96a1-e9132eb74ded'), //test용 postId
-                  ),
-                );
-              },
-              child: const Text('Go to Comment Page'),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pushNamed(context, '/post_create');
-              },
-              child: const Text('Go to Post Create Page'),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pushNamed(context, '/post_list');
-              },
-              child: const Text('Go to Post List Page'),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pushNamed(context, '/splash');
-              },
-              child: const Text('Go to Splash Page'),
-            ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,7 @@ void main() async {
   );
 
   // 테스트용 에러 전송 (완료되면 제거 가능)
-  await Sentry.captureException(StateError('This is a sample exception.'));
+  //await Sentry.captureException(StateError('This is a sample exception.'));
 }
 
 class MyApp extends StatelessWidget {


### PR DESCRIPTION
# feat: 앱 시작 화면을 SplashPage로 변경 및 HomePage 삭제

## 변경 사항
- 앱 실행 시 기존의 HomePage 대신 SplashPage가 시작 화면으로 뜨도록 수정.
- 더 이상 사용하지 않는 HomePage 관련 코드와 UI를 모두 삭제.
- main.dart에서 initialRoute를 '/'에서 '/splash'로 변경하고, '/' 경로도 제거.
- Sentry 초기화 및 샘플 예외 코드  주석처리 (테스트용).

## 목적
- 앱의 첫 진입 화면을 SplashPage로 고정하여 초기 진입 흐름을 명확히 하기 위함.
- 불필요한 HomePage 코드 제거로 코드베이스 간결화 및 유지보수성 향상.

## 참고
- SplashPage 관련 라우트는 유지되어 있어, 이후 SplashPage에서 다음 화면으로 자연스럽게 이동하는 로직 작성 예정
- 기존 HomePage에 있던 네비게이션 버튼 등 삭제
