### PR TITLE
feat: comment_page.dart와 sub_comment_page.dart의 UI를 개선하고 각 댓글마다 대댓글 개…

### DIFF
--- a/lib/presentation/constants/app_styles.dart
+++ b/lib/presentation/constants/app_styles.dart
@@ -50,6 +50,10 @@ class AppStyles {
   static final TextStyle bodyStyle = TextStyle(
     fontSize: 16,
   );
+
+  static final TextStyle commentStyle = TextStyle(
+    fontSize: 20,
+  );
   static final TextStyle tagStyle = GoogleFonts.sunflower(
     color: tagTextColor,
     fontSize: 20,

--- a/lib/presentation/pages/comment_page/comment_page.dart
+++ b/lib/presentation/pages/comment_page/comment_page.dart
@@ -4,7 +4,10 @@ import 'package:flutter_sns_app/core/firebase_analytics_service.dart';
 import 'package:flutter_sns_app/presentation/pages/%08comment_page/sub_comment_page.dart';
 import 'package:intl/intl.dart';
 import '../../../domain/entities/comment.dart';
+import '../../constants/app_styles.dart';
 import '../../providers/comment_provider.dart';
+import '../../providers/sub_comment_provider.dart';
+
 
 class CommentPage extends ConsumerStatefulWidget {
   final String postId;
@@ -51,79 +54,172 @@ class _CommentPageState extends ConsumerState<CommentPage> {
     final comments = ref.watch(commentProvider(widget.postId));
 
     return Scaffold(
+      backgroundColor: AppStyles.backgroundColor,
       appBar: AppBar(
-        title: Text('댓글 ${comments.length}'),
-        leading: BackButton(),
+        backgroundColor: AppStyles.backgroundColor,
+        elevation: 0,
+        title: Text(
+          '댓글 ${comments.length}',
+          style: AppStyles.titleStyle,
+        ),
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: AppStyles.iconColor),
+          onPressed: () => Navigator.pop(context),
+        ),
       ),
       body: Column(
         children: [
           Expanded(
-            child: ListView.separated(
-              itemCount: comments.length,
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              separatorBuilder: (_, __) => Divider(),
-              itemBuilder: (_, index) {
-                final comment = comments[index];
-                return GestureDetector(
-                  onTap: () {
-                    showModalBottomSheet(
-                      context: context,
-                      isScrollControlled: true,
-                      backgroundColor: Colors.transparent,
-                      builder:
-                          (context) => FractionallySizedBox(
-                            heightFactor: 0.8,
-                            child: SubCommentPage(
-                              postId: widget.postId,
-                              parentComment: comment,
+            child: Container(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: [
+                    AppStyles.listBackgroundGradientStart,
+                    AppStyles.listBackgroundGradientEnd,
+                  ],
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                ),
+              ),
+              child: ListView.separated(
+                itemCount: comments.length,
+                padding: AppStyles.pagePadding,
+                separatorBuilder: (_, __) => Container(
+                  margin: EdgeInsets.symmetric(vertical: AppStyles.cardSpacing),
+                  height: AppStyles.dividerThickness,
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [
+                        AppStyles.dividerGradientStart,
+                        AppStyles.dividerGradientEnd,
+                      ],
+                    ),
+                    boxShadow: AppStyles.dividerShadow,
+                  ),
+                ),
+                itemBuilder: (_, index) {
+                  final comment = comments[index];
+                  final subCommentState = ref.watch(subCommentProvider((
+                  postId: widget.postId,
+                  commentId: comment.commentId,
+                  )));
+
+                  // 대댓글 개수 페칭 트리거
+                  ref.read(subCommentProvider((
+                  postId: widget.postId,
+                  commentId: comment.commentId,
+                  )).notifier).fetch();
+
+                  return GestureDetector(
+                    onTap: () {
+                      showModalBottomSheet(
+                        context: context,
+                        isScrollControlled: true,
+                        backgroundColor: Colors.transparent,
+                        builder: (context) => FractionallySizedBox(
+                          heightFactor: AppStyles.overlayHeightRatio,
+                          child: SubCommentPage(
+                            postId: widget.postId,
+                            parentComment: comment,
+                          ),
+                        ),
+                        shape: const RoundedRectangleBorder(
+                          borderRadius: BorderRadius.vertical(
+                            top: Radius.circular(AppStyles.cardBorderRadius),
+                          ),
+                        ),
+                      );
+                    },
+                    child: Container(
+                      padding: AppStyles.cardPadding,
+                      margin: EdgeInsets.symmetric(vertical: AppStyles.cardSpacing),
+                      decoration: BoxDecoration(
+                        color: AppStyles.iconBackgroundColor,
+                        borderRadius: BorderRadius.circular(AppStyles.cardBorderRadius),
+                        boxShadow: AppStyles.defaultShadow,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            comment.text,
+                            style: AppStyles.commentStyle,
+                          ),
+                          SizedBox(height: AppStyles.cardSpacing),
+                          Align(
+                            alignment: Alignment.centerRight,
+                            child: Text(
+                              _formatDate(comment.createdAt),
+                              style: AppStyles.bodyStyle.copyWith(
+                                fontSize: 14,
+                                color: Colors.grey.shade600,
+                              ),
                             ),
                           ),
-                      shape: const RoundedRectangleBorder(
-                        borderRadius: BorderRadius.vertical(
-                          top: Radius.circular(16),
-                        ),
+                          Padding(
+                            padding: EdgeInsets.only(top: AppStyles.cardSpacing),
+                            child: Text(
+                              '대댓글 ${subCommentState.length}개',
+                              style: AppStyles.bodyStyle.copyWith(
+                                fontSize: 18,
+                                color: Colors.black,
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
-                    );
-                  },
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(comment.text, style: TextStyle(fontSize: 16)),
-                      Align(
-                        alignment: Alignment.centerRight,
-                        child: Text(
-                          _formatDate(comment.createdAt),
-                          style: TextStyle(fontSize: 12, color: Colors.grey),
-                        ),
-                      ),
-                    ],
-                  ),
-                );
-              },
+                    ),
+                  );
+                },
+              ),
             ),
           ),
           Container(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-            color: Colors.grey.shade200,
+            padding: AppStyles.contentPadding,
+            decoration: BoxDecoration(
+              color: AppStyles.cardBackgroundColor,
+              boxShadow: AppStyles.defaultShadow,
+            ),
             child: Row(
               children: [
                 Expanded(
                   child: TextField(
                     controller: _controller,
+                    style: AppStyles.bodyStyle,
                     decoration: InputDecoration(
                       hintText: '댓글을 입력하세요',
+                      hintStyle: AppStyles.bodyStyle.copyWith(
+                        color: Colors.grey.shade600,
+                      ),
+                      filled: true,
+                      fillColor: AppStyles.tagBackgroundColor,
                       border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(8),
+                        borderRadius: BorderRadius.circular(AppStyles.cardBorderRadius),
+                        borderSide: BorderSide.none,
                       ),
-                      isDense: true,
-                      contentPadding: const EdgeInsets.symmetric(
-                        vertical: 8,
-                        horizontal: 12,
-                      ),
+                      contentPadding: AppStyles.contentPadding,
                     ),
                   ),
                 ),
-                IconButton(icon: Icon(Icons.send), onPressed: _submitComment),
+                SizedBox(width: AppStyles.cardSpacing),
+                InkWell(
+                  onTap: _submitComment,
+                  splashColor: AppStyles.accentColor.withOpacity(0.2),
+                  borderRadius: BorderRadius.circular(AppStyles.cardBorderRadius),
+                  child: Container(
+                    padding: AppStyles.iconPadding,
+                    decoration: BoxDecoration(
+                      color: AppStyles.iconBackgroundColor,
+                      borderRadius: BorderRadius.circular(AppStyles.cardBorderRadius),
+                      boxShadow: AppStyles.defaultShadow,
+                    ),
+                    child: Icon(
+                      Icons.send,
+                      color: AppStyles.iconColor,
+                      size: AppStyles.iconSizeSmall,
+                    ),
+                  ),
+                ),
               ],
             ),
           ),

--- a/lib/presentation/pages/comment_page/sub_comment_page.dart
+++ b/lib/presentation/pages/comment_page/sub_comment_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import '../../../domain/entities/comment.dart';
 import '../../../domain/entities/sub_comment.dart';
+import '../../constants/app_styles.dart';
 import '../../providers/sub_comment_provider.dart';
 
 class SubCommentPage extends ConsumerStatefulWidget {
@@ -28,9 +29,9 @@ class _SubCommentPageState extends ConsumerState<SubCommentPage> {
     Future.microtask(() {
       ref
           .read(subCommentProvider((
-            postId: widget.postId,
-            commentId: widget.parentComment.commentId,
-          )).notifier)
+      postId: widget.postId,
+      commentId: widget.parentComment.commentId,
+      )).notifier)
           .fetch();
     });
   }
@@ -48,9 +49,9 @@ class _SubCommentPageState extends ConsumerState<SubCommentPage> {
 
     ref
         .read(subCommentProvider((
-          postId: widget.postId,
-          commentId: widget.parentComment.commentId,
-        )).notifier)
+    postId: widget.postId,
+    commentId: widget.parentComment.commentId,
+    )).notifier)
         .create(subComment);
 
     _controller.clear();
@@ -63,83 +64,154 @@ class _SubCommentPageState extends ConsumerState<SubCommentPage> {
   @override
   Widget build(BuildContext context) {
     final subComments = ref.watch(subCommentProvider((
-      postId: widget.postId,
-      commentId: widget.parentComment.commentId,
+    postId: widget.postId,
+    commentId: widget.parentComment.commentId,
     )));
 
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: AppStyles.cardBackgroundColor,
       body: Column(
         children: [
           Container(
             width: double.infinity,
-            padding: const EdgeInsets.all(16),
-            color: Colors.grey.shade100,
+            padding: AppStyles.cardPadding,
+            margin: EdgeInsets.only(bottom: AppStyles.cardSpacing),
+            decoration: BoxDecoration(
+              color: AppStyles.tagBackgroundColor,
+              boxShadow: AppStyles.defaultShadow,
+            ),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(widget.parentComment.text, style: const TextStyle(fontSize: 16)),
-                const SizedBox(height: 4),
+                Text(
+                  widget.parentComment.text,
+                  style: AppStyles.bodyStyle.copyWith(fontWeight: FontWeight.bold),
+                ),
+                SizedBox(height: AppStyles.cardSpacing),
                 Text(
                   _formatDate(widget.parentComment.createdAt),
-                  style: const TextStyle(fontSize: 12, color: Colors.grey),
-                )
+                  style: AppStyles.bodyStyle.copyWith(
+                    fontSize: 12,
+                    color: Colors.grey.shade600,
+                  ),
+                ),
               ],
             ),
           ),
-          const Divider(height: 1),
           Expanded(
-            child: ListView.separated(
-              itemCount: subComments.length,
-              separatorBuilder: (_, __) => Divider(height: 1, color: Colors.grey.shade300),
-              itemBuilder: (_, index) {
-                final reply = subComments[index];
-                return Padding(
-                  padding: const EdgeInsets.only(left: 24, right: 16, top: 12, bottom: 12),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(reply.text),
-                      Align(
-                        alignment: Alignment.centerRight,
-                        child: Text(
-                          _formatDate(reply.createdAt),
-                          style: const TextStyle(fontSize: 12, color: Colors.grey),
-                        ),
-                      )
-                    ],
+            child: Container(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: [
+                    AppStyles.listBackgroundGradientStart,
+                    AppStyles.listBackgroundGradientEnd,
+                  ],
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                ),
+              ),
+              child: ListView.separated(
+                itemCount: subComments.length,
+                padding: AppStyles.pagePadding,
+                separatorBuilder: (_, __) => Container(
+                  margin: EdgeInsets.symmetric(vertical: AppStyles.cardSpacing),
+                  height: AppStyles.dividerThickness,
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [
+                        AppStyles.dividerGradientStart,
+                        AppStyles.dividerGradientEnd,
+                      ],
+                    ),
+                    boxShadow: AppStyles.dividerShadow,
                   ),
-                );
-              },
+                ),
+                itemBuilder: (_, index) {
+                  final reply = subComments[index];
+                  return Container(
+                    padding: AppStyles.cardPadding,
+                    margin: EdgeInsets.only(left: 16, bottom: AppStyles.cardSpacing),
+                    decoration: BoxDecoration(
+                      color: AppStyles.iconBackgroundColor,
+                      borderRadius: BorderRadius.circular(AppStyles.cardBorderRadius),
+                      boxShadow: AppStyles.defaultShadow,
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          reply.text,
+                          style: AppStyles.bodyStyle,
+                        ),
+                        SizedBox(height: AppStyles.cardSpacing),
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: Text(
+                            _formatDate(reply.createdAt),
+                            style: AppStyles.bodyStyle.copyWith(
+                              fontSize: 12,
+                              color: Colors.grey.shade600,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
             ),
           ),
           Container(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-            color: Colors.grey.shade200,
+            padding: AppStyles.contentPadding,
+            decoration: BoxDecoration(
+              color: AppStyles.cardBackgroundColor,
+              boxShadow: AppStyles.defaultShadow,
+            ),
             child: Row(
               children: [
                 Expanded(
                   child: TextField(
                     controller: _controller,
+                    style: AppStyles.bodyStyle,
                     decoration: InputDecoration(
                       hintText: '대댓글을 입력하세요',
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(8),
+                      hintStyle: AppStyles.bodyStyle.copyWith(
+                        color: Colors.grey.shade600,
                       ),
-                      isDense: true,
-                      contentPadding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                      filled: true,
+                      fillColor: AppStyles.tagBackgroundColor,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(AppStyles.cardBorderRadius),
+                        borderSide: BorderSide.none,
+                      ),
+                      contentPadding: AppStyles.contentPadding,
                     ),
                   ),
                 ),
-                IconButton(
-                  icon: const Icon(Icons.send),
-                  onPressed: _submitSubComment,
+                SizedBox(width: AppStyles.cardSpacing),
+                InkWell(
+                  onTap: _submitSubComment,
+                  splashColor: AppStyles.accentColor.withOpacity(0.2),
+                  borderRadius: BorderRadius.circular(AppStyles.cardBorderRadius),
+                  child: Container(
+                    padding: AppStyles.iconPadding,
+                    decoration: BoxDecoration(
+                      color: AppStyles.iconBackgroundColor,
+                      borderRadius: BorderRadius.circular(AppStyles.cardBorderRadius),
+                      boxShadow: AppStyles.defaultShadow,
+                    ),
+                    child: Icon(
+                      Icons.send,
+                      color: AppStyles.iconColor,
+                      size: AppStyles.iconSizeSmall,
+                    ),
+                  ),
                 ),
               ],
             ),
-          )
+          ),
         ],
       ),
     );
   }
-}//
+}


### PR DESCRIPTION
댓글돠 대댓글 페이지의 UI를 개선하고 댓글 컨테이너 마다 몇 개의 대댓글이 있는지 볼 수 있도록 UI에 위젯 추가
<img width="317" alt="스크린샷 2025-05-23 오후 8 23 03" src="https://github.com/user-attachments/assets/783256be-4e70-41c8-8e64-6c761525f393" />
